### PR TITLE
Add texture compression library for Mesa

### DIFF
--- a/BuildRaspbianVc4.py
+++ b/BuildRaspbianVc4.py
@@ -104,6 +104,8 @@ def enableCoredumps():
 	file_put_contents("/etc/security/limits.d/coredump.conf", "*\tsoft\tcore\tunlimited")
 
 def enableDebugEnvVars():
+	# MESA_DEBUG macro needs this library for texture compression
+	subprocess.check_call("apt-get -y install libtxc-dxtn-s2tc0", shell=True)
 	out = "export LIBGL_DEBUG=1\n"
 	out += "export MESA_DEBUG=1\n"
 	out += "export EGL_LOG_LEVEL=debug\n"


### PR DESCRIPTION
(==) Log file: "/usr/local/var/log/Xorg.1.log", Time: Sun Nov 29 07:39:03 2015
(==) Using config file: "/usr/local/etc/X11/xorg.conf"
(==) Using system config directory "/usr/local/share/X11/xorg.conf.d"
libGL: Can't open configuration file /root/.drirc: No such file or directory.
libGL: Can't open configuration file /root/.drirc: No such file or directory.
libEGL debug: Native platform type: drm (autodetected)
libEGL debug: added egl_dri2 to module array
libEGL debug: the best driver is DRI2
**Mesa warning: couldn't open libtxc_dxtn.so, software DXTn compression/decompression unavailable**
libGL: Can't open configuration file /root/.drirc: No such file or directory.
libGL: Can't open configuration file /root/.drirc: No such file or directory.

it's caused by missing specific texture compression library while let MESA_DEBUG on.
ps. refer to [#this](https://bugs.launchpad.net/ubuntu/+source/s2tc/+bug/1023184), but luckily no extra soft link needed on newest raspbian images, it's already /usr/lib/arm-linux-gnueabihf/libtxc_dxtn.so here

@gohai PTAL :)
