### PR TITLE
Drop xserver unit tests build

### DIFF
--- a/BuildRaspbianVc4.py
+++ b/BuildRaspbianVc4.py
@@ -375,7 +375,7 @@ def buildXServer():
 	subprocess.check_call("git remote set-url origin " + XSERVER_GIT_REPO, shell=True)
 	subprocess.call("git fetch", shell=True)
 	subprocess.check_call("git checkout -f -B " + XSERVER_GIT_BRANCH + " origin/" + XSERVER_GIT_BRANCH, shell=True)
-	subprocess.check_call("ACLOCAL_PATH=/usr/local/share/aclocal ./autogen.sh --prefix=/usr/local --enable-glamor --enable-dri2 --enable-dri3 --enable-present", shell=True)
+	subprocess.check_call("ACLOCAL_PATH=/usr/local/share/aclocal ./autogen.sh --prefix=/usr/local --enable-glamor --enable-dri2 --enable-dri3 --enable-present --disable-unit-tests", shell=True)
 	subprocess.check_call("make " + MAKE_OPTS, shell=True)
 	subprocess.check_call("make install", shell=True)
 	# copy xorg.conf


### PR DESCRIPTION
with --disable-unit-tests switch we can cut down build time and test blobs about 240+ megabyte on the storage which is neither installed or run by defaults.

a small improvement, although the CLEANUP will do the real cleanups at last , it does save us time and storage space during building xserver especially for local build. for those who care about unit tests can still invoke its pair switch "enable-unit-tests", what do you think @gohai ?
